### PR TITLE
Added poll command & fixed a few typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 package-lock.json
 .env
-nodes_modules
+node_modules
+
+# vim-related stuff
+.sw[op]

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # DiscordSINFBot
 
-# How to install ?
+## How to install ?
 Clone the project and install the dependencies in the `src` folder by running
-``` npm install```
+```npm install```
 
-Create the `src/.env` folder, put it the content of `.env.example` by modifying the variables appropriately.
-To create a bot and get the token, go to https://discord.com/developers/applications . 
+Create the `src/.env` file, paste in the content of `.env.example` by modifying the variables appropriately.
+To create a bot and get the token, go to https://discord.com/developers/applications.
 
 To "upload" the commands to the Discord helper, run
 ```node deploy-commands.js```
@@ -13,15 +13,13 @@ To "upload" the commands to the Discord helper, run
 To run the bot, execute
 ```node bot.js```
 
-
-
 ## Roadmap dev
-- [ ] An anonymous confession system. Members send a DM to the bot (!confess <message>), the admin approve it in a private channel (with a react) and the message will be then in the public channel) 
-- [x] A bulk clear (!clear <number_message>)
-- [ ] A meme contest event creator (!createcontest <channel_id> <emote> <start_date> <end_date>) with the score command
+- [ ] An anonymous confession system. Members send a DM to the bot (`!confess <message>`), the admin approve it in a private channel (with a react) and the message will be then in the public channel) 
+- [x] A bulk clear (`!clear <number_message>`)
+- [ ] A meme contest event creator (`!createcontest <channel_id> <emote> <start_date> <end_date>`) with the score command
 - [ ] A pin system for members with the role of pin management. (!pin by replying to the message to pin) 
 - [ ] A welcoming DM to newcomers
 - [ ] A poll system
-- [ ] Some funny commands (!poop, !méchant, !criminel,...)
+- [ ] Some funny commands (`!poop`, `!méchant`, `!criminel`,...)
 - [ ] A dynamic !help listing
 - [x] A !version command that return the commit hash on which the bot run

--- a/src/commands/clear.js
+++ b/src/commands/clear.js
@@ -10,7 +10,7 @@ module.exports = {
 		const amount = interaction.options.getInteger('amount');
         console.log(interaction)
         if(!interaction.member.permissions.has(Permissions.FLAGS.MANAGE_MESSAGES)){
-            return interaction.reply({ content: "You don't have the permission to do that."});
+            return interaction.reply({ content: "You don't have the permission to do that.", ephemeral: true });
         }
 
 		if (amount < 1 || amount > 100) {

--- a/src/commands/poll.js
+++ b/src/commands/poll.js
@@ -1,0 +1,67 @@
+const { SlashCommandBuilder } = require("@discordjs/builders");
+const { MessageEmbed } = require("discord.js");
+
+module.exports = {
+	data: new SlashCommandBuilder()
+		.setName("poll")
+		.setDescription("Creates a poll")
+		.addStringOption(option => option
+			.setName("question")
+			.setDescription("Poll question"))
+
+		// unfortunately, Discord slash commands don't yet support variadic arguments: https://github.com/discord/discord-api-docs/issues/2331
+
+		.addStringOption(option => option
+			.setName("answers")
+			.setDescription("Possible poll answers")),
+
+	async execute(interaction) {
+		const question = interaction.options.getString("question");
+		const answers = interaction.options.getString("answers")?.split(' ').map(x => x.replaceAll('_', ' '));
+
+		if (!question) {
+			return interaction.reply({ content: "You must provide a value for the question option", ephemeral: true });
+		}
+
+		const answer_emojis = ["0️⃣", "1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣"];
+
+		if (answers?.length == 1) {
+			return interaction.reply({ content: "A poll may not have a single possible answer" });
+		}
+
+		if (answers?.length > 10) {
+			return interaction.reply({ content: `You may not have more than ${answer_emojis.length} possible answers (you passed ${answers.length})`, ephemeral: true });
+		}
+
+		let poll_content = "";
+
+		if (answers) {
+			for (const [i, answer] of answers.entries()) {
+				poll_content += `${answer_emojis[i]} ${answer}\n`;
+			}
+		}
+
+		const embed = new MessageEmbed()
+			.setTitle(question)
+			.setDescription(poll_content)
+			.setAuthor(interaction.user.username)
+			.setColor(interaction.user.accent_color)
+			.setThumbnail("https://cdn.discordapp.com/emojis/770002495614877738.png?size=44");
+
+		await interaction.reply({ embeds: [embed] });
+		const message = await interaction.fetchReply();
+
+		// add reactions
+
+		for (let i = 0; i < answers?.length; i++) {
+			message.react(answer_emojis[i]);
+		}
+
+		if (!answers) {
+			message.react("✅");
+			message.react("❌");
+		}
+
+		return message;
+	},
+};

--- a/src/commands/poll.js
+++ b/src/commands/poll.js
@@ -26,7 +26,7 @@ module.exports = {
 		const answer_emojis = ["0️⃣", "1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣"];
 
 		if (answers?.length == 1) {
-			return interaction.reply({ content: "A poll may not have a single possible answer" });
+			return interaction.reply({ content: "A poll may not have a single possible answer", ephemeral: true });
 		}
 
 		if (answers?.length > answer_emojis.length) {

--- a/src/commands/poll.js
+++ b/src/commands/poll.js
@@ -29,7 +29,7 @@ module.exports = {
 			return interaction.reply({ content: "A poll may not have a single possible answer" });
 		}
 
-		if (answers?.length > 10) {
+		if (answers?.length > answer_emojis.length) {
 			return interaction.reply({ content: `You may not have more than ${answer_emojis.length} possible answers (you passed ${answers.length})`, ephemeral: true });
 		}
 

--- a/src/package.json
+++ b/src/package.json
@@ -1,4 +1,7 @@
 {
+  "name": "discord-sinf-bot",
+  "description": "The Discord bot of students in Computer Science at UCLouvain",
+  "homepage": "https://github.com/fdardenne/DiscordSINFBot",
   "dependencies": {
     "@discordjs/rest": "0.1.0-canary.0",
     "discord-api-types": "^0.23.1",


### PR DESCRIPTION
Referring to #5.
Poll command is invoked as follows, with a mandatory `question` option, and an optional `answers` option:

![image](https://user-images.githubusercontent.com/11079650/145166802-a6f2a6b1-298b-4b22-8466-779e2c028aa5.png)

Underscores in answers will be substituted for spaces, so that you can use spaces in your answers. Perhaps this isn't the best solution (maybe using commas as a delimiter is better?), so I'm open to other suggestions :smile: 

This produces the following output:

![image](https://user-images.githubusercontent.com/11079650/145167144-3094d161-7ce2-4f66-af41-8b94a667bcd9.png)

Providing no answers produces this:

![image](https://user-images.githubusercontent.com/11079650/145167465-6883644a-bfc1-480b-a697-270dedf57dfa.png)
