### PR TITLE
thanks: fix for weird `git-shortlog` behaviour

### DIFF
--- a/src/commands/thanks.js
+++ b/src/commands/thanks.js
@@ -10,8 +10,6 @@ module.exports = {
         .execSync("git shortlog -sne HEAD | awk '!_[$NF]++' | awk '{$1=$NF=\"\"}1' | awk '{$1=$1}1'")
         .toString()
 
-        console.log(contributor)
-
         const embed = new MessageEmbed()
                                 .setTitle('Thanks')
                                 .setDescription(contributor)

--- a/src/commands/thanks.js
+++ b/src/commands/thanks.js
@@ -4,11 +4,13 @@ const { MessageEmbed } = require("discord.js");
 module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('thanks')
-		.setDescription('Return the list of my contributor'),
+		.setDescription('Return the list of my contributors'),
 	async execute(client, interaction) {
         contributor = require('child_process')
-        .execSync("git shortlog -sne | awk '!_[$NF]++' | awk '{$1=$NF=""}1' | awk '{$1=$1}1''") 
-        .toString().trim()
+        .execSync("git shortlog -sne HEAD | awk '!_[$NF]++' | awk '{$1=$NF=\"\"}1' | awk '{$1=$1}1'")
+        .toString()
+
+        console.log(contributor)
 
         const embed = new MessageEmbed()
                                 .setTitle('Thanks')


### PR DESCRIPTION
For some reason:
> If no revisions are passed on the command line and either standard input is not a terminal or there is no current branch, git shortlog will output a summary of the log read from standard input, without reference to the current repository.

(from `man git-shortlog`)
